### PR TITLE
fix: date did not appear

### DIFF
--- a/scan2html
+++ b/scan2html
@@ -31,7 +31,7 @@ function scan {
   {
     echo "const trivyData = "
     cat "$BASEDIR"/$tmp_json_file
-    echo "const createdAt = $(date +%s) * 1000"
+    echo "const createdAt = $(date +%s)"
     cat "$BASEDIR"/second.html
   } >>$last_arg
 

--- a/scan2html
+++ b/scan2html
@@ -31,7 +31,7 @@ function scan {
   {
     echo "const trivyData = "
     cat "$BASEDIR"/$tmp_json_file
-    echo "const createdAt = $(date +%s%3)"
+    echo "const createdAt = $(date +%s) * 1000"
     cat "$BASEDIR"/second.html
   } >>$last_arg
 

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -278,7 +278,7 @@ function renderCreatedAt() {
     return console.error("Creation timestamp not loaded");
   }
   const titleTimeElem = document.querySelector("#title-time");
-  titleTimeElem.innerHTML = new Date(createdAt).toLocaleString();
+  titleTimeElem.innerHTML = new Date(createdAt * 1000).toLocaleString();
   document.title += " " + titleTimeElem.innerHTML;
 }
 


### PR DESCRIPTION
The JavaScript Date() constructor accepts the number of **milliseconds** since January 1, 1970, 00:00:00 UTC